### PR TITLE
Fix invalid condensed light italic font paths

### DIFF
--- a/_open-sans-condensedlight.scss
+++ b/_open-sans-condensedlight.scss
@@ -11,5 +11,5 @@ $FontPathOpenSans: "./fonts" !default;
   font-family: 'Open Sans Condensed';
   font-weight: 300;
   font-style: italic;
-  src: url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.woff2') format('woff2'), url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.woff') format('woff'), url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.ttf') format('truetype'), url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.svg#OpenSansCondensedLightItalic') format('svg');
+  src: url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff2') format('woff2'), url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff') format('woff'), url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.ttf') format('truetype'), url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.svg#OpenSansCondensedLightItalic') format('svg');
 }

--- a/open-sans.scss
+++ b/open-sans.scss
@@ -111,7 +111,7 @@ $FontPathOpenSans: "./fonts" !default;
   font-family: 'Open Sans Condensed';
   font-weight: 300;
   font-style: italic;
-  src: url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.woff2') format('woff2'), url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.woff') format('woff'), url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.ttf') format('truetype'), url('#{$FontPathOpenSans}/CondensedLight/OpenSans-CondensedLightItalic.svg#OpenSansCondensedLightItalic') format('svg');
+  src: url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff2') format('woff2'), url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.woff') format('woff'), url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.ttf') format('truetype'), url('#{$FontPathOpenSans}/CondensedLightItalic/OpenSans-CondensedLightItalic.svg#OpenSansCondensedLightItalic') format('svg');
 }
 
 @font-face {


### PR DESCRIPTION
Scss source does not compile when including condensed light fonts, as the folder names are not corresponding to the name in the repository and npm package.
This means that I cannot include open-sans simply like this:
`
$FontPathOpenSans: './open-sans';
@import "../../node_modules/open-sans-fonts/open-sans.scss";
`
where I just copy the whole font directory to ./open-sans.