### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can do the same with Stylus too ...
 
 ```
 # part of your SCSS file
-$FontPathOpenSans = "../fonts/open-sans";
+$FontPathOpenSans = "open-sans/";
 @import '../../../node_modules/open-sans-fonts/open-sans.styl';
 ```
 


### PR DESCRIPTION
On a clean npm install > npm i open-sans-fonts --save
The path to the fonts has to be relative to the open-sans.scss
and there it it just "open-sans/"